### PR TITLE
Add struct reference embedding via tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 # env file
 .env
 .direnv
+package.json
+package-lock.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,3 +1,111 @@
 # genstruct
 
-generate statically defined golang structs
+A Go library for generating statically defined Go structs with support for references between structures.
+
+## Features
+
+- Generate Go code for static structs and arrays
+- Automatic creation of constants, variables, and slices
+- Smart naming of variables based on identifier fields
+- Reference embedding via struct tags to connect related structs
+- Customizable code generation
+
+## Installation
+
+```bash
+go get github.com/conneroisu/genstruct
+```
+
+## Basic Usage
+
+```go
+// Define your struct type
+type Animal struct {
+    ID     string
+    Name   string
+    Species string
+    Diet   string
+}
+
+// Create a slice of structs
+animals := []Animal{
+    {ID: "lion-001", Name: "Leo", Species: "Lion", Diet: "Carnivore"},
+    {ID: "tiger-001", Name: "Stripes", Species: "Tiger", Diet: "Carnivore"},
+}
+
+// Configure the generator
+config := genstruct.Config{
+    PackageName:   "zoo",          // Target package name
+    TypeName:      "Animal",       // Struct type name
+    ConstantIdent: "Animal",       // Prefix for constants
+    VarPrefix:     "Animal",       // Prefix for variables
+    OutputFile:    "animals.go",   // Output file path
+}
+
+// Generate the code
+generator := genstruct.NewGenerator(config, animals)
+err := generator.Generate()
+```
+
+## Struct Reference Embedding
+
+A powerful feature of genstruct is the ability to automatically populate fields in one struct by referencing values from another struct.
+
+### How it works
+
+1. Define your structs with reference fields
+2. Use the `structgen` tag to specify the source field
+3. Pass additional reference datasets to `NewGenerator`
+
+### Example
+
+```go
+// Define your tag struct
+type Tag struct {
+    ID   string
+    Name string
+    Slug string
+}
+
+// Define your post struct with references to tags
+type Post struct {
+    ID       string
+    Title    string
+    TagSlugs []string  // Contains tag slugs
+    Tags     []Tag     `structgen:"TagSlugs"` // Will be populated from TagSlugs
+}
+
+// Create your data
+tags := []Tag{
+    {ID: "tag-001", Name: "Go", Slug: "go"},
+    {ID: "tag-002", Name: "Programming", Slug: "programming"},
+}
+
+posts := []Post{
+    {
+        ID: "post-001", 
+        Title: "Introduction to Go",
+        TagSlugs: []string{"go", "programming"},
+    },
+}
+
+// Generate code with both datasets
+generator := genstruct.NewGenerator(config, posts, tags)
+err := generator.Generate()
+```
+
+The generated code will include Posts with their Tags field populated from the referenced Tags.
+
+## Config Options
+
+- `PackageName`: The package name for the generated file
+- `TypeName`: The name of the struct type
+- `ConstantIdent`: Prefix for generated constants
+- `VarPrefix`: Prefix for generated variables
+- `OutputFile`: The output file path
+- `IdentifierFields`: Fields to use for naming (default: "ID", "Name", "Slug", "Title", "Key", "Code")
+- `CustomVarNameFn`: Optional function to customize variable naming
+
+## Dependencies
+
+- [jennifer](https://github.com/dave/jennifer) for code generation

--- a/WHY.md
+++ b/WHY.md
@@ -1,0 +1,125 @@
+# Why Genstruct?
+
+## The Problem
+
+Static data in Go applications often presents several challenges:
+
+1. **Runtime Overhead**: Loading data from external sources (JSON, YAML, databases) at runtime adds latency and complexity
+2. **Type Safety**: External data formats lack compile-time type checking, leading to potential runtime errors
+3. **IDE Support**: External data doesn't benefit from IDE features like autocompletion, refactoring, and documentation
+4. **Testing**: External data makes tests more complex and harder to reason about
+5. **Deployment**: External data files need to be packaged and deployed alongside your application
+6. **Relationships**: Managing relationships between different data types becomes manual and error-prone
+
+## The Solution
+
+Genstruct addresses these challenges by moving data from external sources into Go code:
+
+### Compile-Time Verification
+
+By generating Go code, all data is verified at compile-time:
+
+- Type errors are caught before your application runs
+- Syntax or format errors become impossible
+- Missing or malformed data is immediately apparent
+
+### Performance Benefits
+
+Static data compilation provides significant performance advantages:
+
+- No runtime loading or parsing overhead
+- Zero allocation overhead compared to unmarshaling JSON/YAML
+- Instant access to data without initialization code
+- Reduced memory usage (no map-based intermediate structures)
+
+### Developer Experience
+
+The development experience is dramatically improved:
+
+- Full IDE support with autocompletion
+- Jump-to-definition for data references
+- Inline documentation for data structures
+- Simplified refactoring and renaming
+- Consistent code structure for both logic and data
+
+### Relationships Between Data
+
+With the struct reference embedding feature:
+
+- Relationships between different data types are automatically managed
+- References maintain type safety and refactoring support
+- Data consistency is enforced at compile time
+- Changes to reference fields are tracked through the type system
+
+## When to Use Genstruct
+
+Genstruct is ideal for applications that have:
+
+1. **Reference Data**: Lists of countries, categories, permissions, etc.
+2. **Configuration Constants**: Feature flags, limits, defaults
+3. **Enumerated Types**: Status values, types, classifications
+4. **Content Libraries**: Help content, error messages, documentation
+5. **Related Data**: Blog posts with tags, products with categories, users with roles
+
+## When Not to Use Genstruct
+
+Genstruct may not be the best solution for:
+
+1. **Highly Dynamic Data**: Data that changes frequently at runtime
+2. **Extremely Large Datasets**: Datasets with thousands of entries (though this depends on usage patterns)
+3. **User-Generated Content**: Content created and modified by end-users
+4. **Data Requiring External Editing**: When non-developers need to frequently edit the data
+
+## Real-World Use Cases
+
+### Content Management Systems
+
+Pre-generate content structures while allowing runtime content to reference these structures:
+
+```go
+// Generated site sections
+var SectionNews = Section{...}
+var SectionBlog = Section{...}
+
+// Runtime content referencing static structures
+content.Section = SectionNews
+```
+
+### E-commerce Product Catalogs
+
+Define product categories, attributes, and relationships statically:
+
+```go
+// Access static product categories
+for product in dynamicProducts {
+    if product.CategorySlug == ProductCategorySportwear.Slug {
+        // Process sporting goods
+    }
+}
+```
+
+### API Specifications
+
+Generate API endpoints, parameters, and response types:
+
+```go
+// Check if an endpoint requires authentication
+if APIEndpointUserProfile.RequiresAuth {
+    // Perform authentication
+}
+```
+
+### Internationalization and Localization
+
+Generate language packs and translations:
+
+```go
+// Access translations
+message := LocaleEnUs.Errors.NotFound
+```
+
+## Conclusion
+
+Genstruct transforms the way you work with static data in Go by bringing it into the type system, improving performance, developer experience, and reliability. By generating Go code from your data, you get the best of both worlds: the flexibility of external data formats with the robustness and safety of the Go compiler.
+
+The new reference embedding feature takes this concept further by automatically managing relationships between different data types, reducing boilerplate code and potential errors while maintaining all the benefits of compile-time verification.

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Installation](./install.md)
+- [Struct Reference Embedding](./references.md)

--- a/doc/src/install.md
+++ b/doc/src/install.md
@@ -1,7 +1,187 @@
-# Install As A Package
+# Installation and Getting Started
 
-## Get using Go (recommended)
+## Installation Options
+
+### Using Go Modules (Recommended)
+
+The recommended way to install genstruct is using Go modules:
 
 ```bash
+# Initialize your module if you haven't already
+go mod init example.com/myproject
+
+# Add genstruct to your project
 go get github.com/conneroisu/genstruct
 ```
+
+### Manual Installation
+
+You can also clone the repository directly:
+
+```bash
+git clone https://github.com/conneroisu/genstruct.git
+cd genstruct
+go install
+```
+
+## Quick Start Guide
+
+Here's how to start using genstruct in your project:
+
+### 1. Define Your Structs
+
+Create the structs that you want to generate static data for:
+
+```go
+// Example: animal.go
+package zoo
+
+import "time"
+
+type Animal struct {
+    ID           string
+    Name         string
+    Species      string
+    DateOfBirth  time.Time
+    Diet         string
+    Weight       float64
+    IsEndangered bool
+}
+```
+
+### 2. Create a Generator
+
+Set up a generator in your code:
+
+```go
+package main
+
+import (
+    "github.com/conneroisu/genstruct"
+    "time"
+)
+
+func main() {
+    // Define sample data
+    animals := []Animal{
+        {
+            ID:           "lion-001",
+            Name:         "Leo",
+            Species:      "African Lion",
+            DateOfBirth:  time.Date(2018, time.March, 15, 0, 0, 0, 0, time.UTC),
+            Diet:         "Carnivore",
+            Weight:       180.5,
+            IsEndangered: true,
+        },
+        // Add more animals...
+    }
+    
+    // Configure genstruct
+    config := genstruct.Config{
+        PackageName:      "zoo",         // Target package name
+        TypeName:         "Animal",      // The struct type name
+        ConstantIdent:    "Animal",      // Prefix for constants
+        VarPrefix:        "Animal",      // Prefix for variables
+        OutputFile:       "animals.go",  // Output file name
+        IdentifierFields: []string{"Name", "Species"}, // Fields used for naming
+    }
+    
+    // Create generator
+    generator := genstruct.NewGenerator(config, animals)
+    
+    // Generate the code
+    err := generator.Generate()
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+### 3. Run Your Generator
+
+Execute your generator:
+
+```bash
+go run main.go
+```
+
+This will create `animals.go` with your static data.
+
+### 4. Use the Generated Code
+
+Import and use the generated code:
+
+```go
+package main
+
+import (
+    "fmt"
+    "yourmodule/zoo" // Import the generated package
+)
+
+func main() {
+    // Access specific animal
+    fmt.Println(zoo.AnimalLeo.Species) // Prints: African Lion
+    
+    // Access all animals
+    for _, animal := range zoo.AllAnimals {
+        fmt.Printf("%s: %s\n", animal.Name, animal.Species)
+    }
+}
+```
+
+## Advanced: Using Struct References
+
+For more complex data structures with relationships:
+
+```go
+// Define related structs
+type Tag struct {
+    ID   string
+    Name string
+    Slug string
+}
+
+type Post struct {
+    ID       string
+    Title    string
+    TagSlugs []string  // References to tags
+    Tags     []Tag     `structgen:"TagSlugs"` // Will be populated from TagSlugs
+}
+
+// Create datasets
+tags := []Tag{
+    {ID: "tag-1", Name: "Go", Slug: "go"},
+    // More tags...
+}
+
+posts := []Post{
+    {
+        ID:       "post-1",
+        Title:    "Go Programming",
+        TagSlugs: []string{"go"},
+    },
+    // More posts...
+}
+
+// Create generator with both datasets
+generator := genstruct.NewGenerator(config, posts, tags)
+
+// Generate code with relationships
+err := generator.Generate()
+```
+
+## Common Configuration Options
+
+Here are some common configuration options:
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| PackageName | Target package name | `"models"` |
+| TypeName | Struct type name | `"User"` |
+| ConstantIdent | Prefix for constants | `"User"` |
+| VarPrefix | Prefix for variables | `"User"` |
+| OutputFile | Output file path | `"users.go"` |
+| IdentifierFields | Priority fields for naming | `[]string{"ID", "Username"}` |
+
+For more examples, see the [examples directory](https://github.com/conneroisu/genstruct/tree/main/examples) in the repository.

--- a/doc/src/references.md
+++ b/doc/src/references.md
@@ -1,0 +1,119 @@
+# Struct Reference Embedding
+
+One of the powerful features of `genstruct` is the ability to automatically populate fields in one struct with references to other structs. This allows you to define relationships between your data structures and have them automatically resolved during code generation.
+
+## How It Works
+
+References between structs are established using Go struct tags with the `structgen` tag:
+
+```go
+type Post struct {
+    ID       string    
+    TagSlugs []string       // Contains slugs of tags
+    Tags     []Tag     `structgen:"TagSlugs"` // Will be populated based on TagSlugs
+}
+```
+
+The `structgen` tag tells `genstruct` that:
+
+1. The value of this field (`Tags`) should be populated based on the value of another field (`TagSlugs`)
+2. It should look up matching values in the reference data provided
+
+## Supported Reference Types
+
+Currently, `genstruct` supports two types of references:
+
+1. **String to Struct**: A string field referencing a single struct
+   ```go
+   type Post struct {
+       AuthorID string            // Contains an author ID
+       Author   Author     `structgen:"AuthorID"` // Will be populated from AuthorID
+   }
+   ```
+
+2. **String Slice to Struct Slice**: A slice of strings referencing a slice of structs
+   ```go
+   type Post struct {
+       TagSlugs []string       // Contains slugs of tags
+       Tags     []Tag     `structgen:"TagSlugs"` // Will be populated as a slice of Tags
+   }
+   ```
+
+## How to Use References
+
+To use struct references:
+
+1. Define your data structures with appropriate reference fields
+2. Add `structgen` tags to fields that should be populated from references
+3. Pass all required datasets to `NewGenerator`
+
+### Example
+
+```go
+// Define tag struct
+type Tag struct {
+    ID   string
+    Name string
+    Slug string
+}
+
+// Define post struct with references to tags
+type Post struct {
+    ID       string
+    Title    string
+    TagSlugs []string  // Contains tag slugs
+    Tags     []Tag     `structgen:"TagSlugs"` // Will be populated from TagSlugs
+}
+
+// Create your datasets
+tags := []Tag{
+    {ID: "tag-001", Name: "Go", Slug: "go"},
+    {ID: "tag-002", Name: "Programming", Slug: "programming"},
+}
+
+posts := []Post{
+    {
+        ID: "post-001", 
+        Title: "Introduction to Go",
+        TagSlugs: []string{"go", "programming"},
+    },
+}
+
+// Generate code with both datasets
+generator := genstruct.NewGenerator(config, posts, tags)
+err := generator.Generate()
+```
+
+## How genstruct Finds Matching References
+
+When looking for matching references, `genstruct` tries each of the identifier fields in order:
+
+1. For each value in the source field (e.g., each string in `TagSlugs`)
+2. It looks through each struct in the reference dataset (e.g., each `Tag`)
+3. It tries each identifier field (`ID`, `Name`, `Slug`, etc.) to find a match
+4. When a match is found, that struct is added to the result
+
+The identifier fields are specified in `Config.IdentifierFields`, with a default of `["ID", "Name", "Slug", "Title", "Key", "Code"]`.
+
+## Edge Cases
+
+- **Missing References**: If a referenced value doesn't exist in the reference dataset, it will be omitted from the result.
+- **Empty Source**: If the source field is empty, the target field will be an empty slice or struct.
+- **Invalid Types**: If the source and target field types don't match the supported reference patterns, the field will be ignored.
+
+## Limitations
+
+Currently, there are some limitations to be aware of:
+
+1. Only string-based lookups are supported (string to struct, string slice to struct slice)
+2. References must be between simple types (no nested struct references)
+3. References are resolved during code generation, not at runtime
+
+## Future Extensions
+
+Future versions may include:
+
+- Support for custom lookup logic
+- Bidirectional references
+- Deeper nested references
+- More complex mapping relationships

--- a/examples/blog-posts-tags/.gitignore
+++ b/examples/blog-posts-tags/.gitignore
@@ -1,0 +1,9 @@
+# Generated Go files
+blog_posts.go
+
+# IDE files
+.idea/
+.vscode/
+
+# Build files
+*.exe

--- a/examples/blog-posts-tags/main.go
+++ b/examples/blog-posts-tags/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/conneroisu/genstruct"
+)
+
+// Tag represents a blog post tag
+type Tag struct {
+	ID   string // Unique identifier for the tag
+	Name string // Name of the tag
+	Slug string // URL-friendly slug for the tag
+}
+
+// Post represents a blog post
+type Post struct {
+	ID       string    // Unique identifier for the post
+	Title    string    // Title of the post
+	Slug     string    // URL-friendly slug for the post
+	Content  string    // Content of the post
+	TagSlugs []string  // List of tag slugs
+	Tags     []Tag     `structgen:"TagSlugs"` // Populated from TagSlugs
+	Date     time.Time // Publication date
+}
+
+// generateBlogData generates the static blog data file
+func generateBlogData() error {
+	// Define our array of tag data
+	tags := []Tag{
+		{
+			ID:   "tag-001",
+			Name: "Go Programming",
+			Slug: "go-programming",
+		},
+		{
+			ID:   "tag-002",
+			Name: "Code Generation",
+			Slug: "code-generation",
+		},
+		{
+			ID:   "tag-003",
+			Name: "Tutorials",
+			Slug: "tutorials",
+		},
+		{
+			ID:   "tag-004",
+			Name: "Developer Tools",
+			Slug: "developer-tools",
+		},
+	}
+
+	// Define our array of post data
+	posts := []Post{
+		{
+			ID:       "post-001",
+			Title:    "Introduction to Go",
+			Slug:     "introduction-to-go",
+			Content:  "Go is a statically typed programming language...",
+			TagSlugs: []string{"go-programming", "tutorials"},
+			Date:     time.Date(2023, time.January, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:       "post-002",
+			Title:    "Code Generation in Go",
+			Slug:     "code-generation-in-go",
+			Content:  "Code generation can save time and reduce errors...",
+			TagSlugs: []string{"go-programming", "code-generation", "developer-tools"},
+			Date:     time.Date(2023, time.February, 20, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:       "post-003",
+			Title:    "Building Developer Tools",
+			Slug:     "building-developer-tools",
+			Content:  "Developer tools can greatly enhance productivity...",
+			TagSlugs: []string{"developer-tools", "tutorials"},
+			Date:     time.Date(2023, time.March, 5, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	// Configure genstruct
+	config := genstruct.Config{
+		PackageName:      "main",                // Target package name
+		TypeName:         "Post",                // The struct type name
+		ConstantIdent:    "Post",                // Prefix for constants
+		VarPrefix:        "Post",                // Prefix for variables
+		OutputFile:       "blog_posts.go",       // Output file name
+		IdentifierFields: []string{"Slug", "ID"}, // Fields to use for naming variables
+	}
+
+	// Create a new generator with our config, posts, and tags
+	// The tags are passed as a reference dataset
+	generator := genstruct.NewGenerator(config, posts, tags)
+
+	// Generate the code
+	return generator.Generate()
+}
+
+func main() {
+	// Generate the blog post data
+	fmt.Println("Generating static blog post data...")
+	err := generateBlogData()
+	if err != nil {
+		fmt.Printf("Error generating code: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Successfully generated static blog post data in blog_posts.go")
+
+	// Show the content of the generated file
+	content, err := os.ReadFile("blog_posts.go")
+	if err != nil {
+		fmt.Printf("Error reading generated file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("\nContents of generated file:")
+	fmt.Println("---------------------------")
+	fmt.Println(string(content))
+
+	fmt.Println("\nTo use the generated code in your application you would:")
+	fmt.Println("1. Import the generated file in your code by its package name")
+	fmt.Println("2. Use main.PostIntroductionToGo, main.PostCodeGenerationInGo, etc. to access specific posts")
+	fmt.Println("3. Use main.AllPosts slice for filtering and analysis")
+	fmt.Println("4. The Tags field in each post will be populated from TagSlugs referencing the tags by slug")
+}

--- a/examples/blog-posts-tags/main_test.go
+++ b/examples/blog-posts-tags/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBlogPostsGeneration(t *testing.T) {
+	// Run the generation
+	err := generateBlogData()
+	if err != nil {
+		t.Fatalf("Error generating blog posts: %v", err)
+	}
+
+	// Read the generated file
+	content, err := os.ReadFile("blog_posts.go")
+	if err != nil {
+		t.Fatalf("Error reading generated file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Test that generated code contains expected elements
+	expectedTests := []struct {
+		name     string
+		expected string
+		message  string
+	}{
+		{
+			name:     "Post constants",
+			expected: "PostIntroductionToGoID",
+			message:  "Should contain post ID constants",
+		},
+		{
+			name:     "Post variables",
+			expected: "var PostIntroductionToGo = Post{",
+			message:  "Should contain post variables",
+		},
+		{
+			name:     "Post slice",
+			expected: "var AllPosts = []Post{",
+			message:  "Should contain AllPosts slice",
+		},
+		{
+			name:     "Has first post with tags",
+			expected: "Tags: []Tag{",
+			message:  "Should contain Tags field with array",
+		},
+		{
+			name:     "Tag reference values",
+			expected: "Name: \"Go Programming\"",
+			message:  "Should contain referenced tag values",
+		},
+		{
+			name:     "Second tag reference values",
+			expected: "Name: \"Tutorials\"",
+			message:  "Should contain all referenced tag values",
+		},
+		{
+			name:     "Complex post reference",
+			expected: "CodeGeneration",
+			message:  "Should contain values from posts with multiple tags",
+		},
+	}
+
+	for _, tc := range expectedTests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(contentStr, tc.expected) {
+				t.Errorf("%s: %q not found in generated code", tc.message, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	// This runs after all tests to clean up
+	os.Remove("blog_posts.go")
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,111 @@
+package genstruct
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tag is a test struct for reference embedding
+type Tag struct {
+	ID   string
+	Name string
+	Slug string
+}
+
+// Post is a test struct that references Tags
+type Post struct {
+	ID       string
+	Title    string
+	Date     time.Time
+	TagSlugs []string
+	Tags     []Tag `structgen:"TagSlugs"`
+}
+
+func TestStructReferenceEmbedding(t *testing.T) {
+	// Create test data
+	tags := []Tag{
+		{ID: "tag-1", Name: "Go", Slug: "go"},
+		{ID: "tag-2", Name: "Programming", Slug: "programming"},
+		{ID: "tag-3", Name: "Testing", Slug: "testing"},
+	}
+
+	posts := []Post{
+		{
+			ID:       "post-1",
+			Title:    "Testing in Go",
+			Date:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			TagSlugs: []string{"go", "testing"},
+		},
+		{
+			ID:       "post-2",
+			Title:    "Go Programming",
+			Date:     time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			TagSlugs: []string{"go", "programming"},
+		},
+	}
+
+	// Create config
+	config := Config{
+		PackageName:      "testdata",
+		TypeName:         "Post",
+		ConstantIdent:    "Post",
+		VarPrefix:        "Post",
+		OutputFile:       "test_posts.go",
+		IdentifierFields: []string{"Slug", "ID"},
+	}
+
+	// Create generator with references
+	generator := NewGenerator(config, posts, tags)
+
+	// Make sure Refs map is correctly populated
+	if len(generator.Refs) != 1 {
+		t.Errorf("Expected 1 reference type, got %d", len(generator.Refs))
+	}
+
+	tagRef, ok := generator.Refs["Tag"]
+	if !ok {
+		t.Fatal("Expected to find Tag in references")
+	}
+
+	// Verify the generator stored the correct reference data
+	tagRefValue := reflect.ValueOf(tagRef)
+	if tagRefValue.Len() != 3 {
+		t.Errorf("Expected 3 tags in reference data, got %d", tagRefValue.Len())
+	}
+
+	// Generate the code
+	err := generator.Generate()
+	if err != nil {
+		t.Fatalf("Error generating code: %v", err)
+	}
+
+	// Read the generated file
+	content, err := os.ReadFile("test_posts.go")
+	if err != nil {
+		t.Fatalf("Error reading generated file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Test that the references are properly populated
+	expectedRefs := []string{
+		// Fields from Tag structs
+		"Name: \"Go\"",
+		"Name: \"Testing\"",
+		"Name: \"Programming\"",
+		// Verify structs are properly referenced
+		"Tags: []Tag{",
+	}
+
+	for _, expected := range expectedRefs {
+		if !strings.Contains(contentStr, expected) {
+			t.Errorf("Expected to find %q in generated code", expected)
+		}
+	}
+
+	// Clean up
+	os.Remove("test_posts.go")
+}


### PR DESCRIPTION
## Summary
- Add the ability to create relationships between different structs using struct tags
- Allow automatic population of fields by looking up values in reference datasets
- Support both string-to-struct and string-slice-to-struct-slice references
- Add comprehensive documentation and examples in blog-posts-tags

## Test plan
- Run unit tests with `go test ./...`
- Verify examples work with `go run examples/blog-posts-tags/main.go`
- Check generated documentation with `generate-all`

🤖 Generated with [Claude Code](https://claude.ai/code)